### PR TITLE
fix: rename CLI bin to clsh-dev to match npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6383,14 +6383,14 @@
     },
     "packages/cli": {
       "name": "clsh-dev",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@clsh/agent": "0.0.1",
         "@clsh/web": "0.0.1"
       },
       "bin": {
-        "clsh": "dist/index.js"
+        "clsh-dev": "dist/index.js"
       },
       "devDependencies": {
         "tsx": "^4.19.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clsh-dev",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Your Mac, in your pocket. Real terminal on your phone.",
   "license": "MIT",
   "repository": {
@@ -15,7 +15,7 @@
   "type": "module",
   "files": ["dist"],
   "bin": {
-    "clsh": "dist/index.js"
+    "clsh-dev": "dist/index.js"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Renamed bin from `clsh` to `clsh-dev` to match the npm package name
- npx requires bin name = package name to work correctly
- Bumped to 0.1.1 (already published to npm)

## Test plan

- [x] `npx clsh-dev --help` works (tested from /tmp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)