### PR TITLE
feat: add GitHub link to startup banner

### DIFF
--- a/packages/agent/src/tunnel.ts
+++ b/packages/agent/src/tunnel.ts
@@ -204,6 +204,8 @@ export function printAccessInfo(
       console.log(`${dim}     Set NGROK_AUTHTOKEN in .env for remote access.${r}`);
     }
     console.log('');
+    console.log(`${dim}  GitHub: https://github.com/my-claude-utils/clsh${r}`);
+    console.log('');
   });
 }
 


### PR DESCRIPTION
## Summary
- Adds GitHub repo link (dimmed) at the bottom of the `npx clsh-dev` startup banner

## Test plan
- [ ] Run `npx clsh-dev` and verify GitHub link appears after access info

🤖 Generated with [Claude Code](https://claude.com/claude-code)