### PR TITLE
chore: bump @clsh/agent to 0.0.2 and clsh-dev to 0.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6363,7 +6363,7 @@
     },
     "packages/agent": {
       "name": "@clsh/agent",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@ngrok/ngrok": "^1.4.0",
@@ -6383,10 +6383,10 @@
     },
     "packages/cli": {
       "name": "clsh-dev",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
-        "@clsh/agent": "0.0.1",
+        "@clsh/agent": "0.0.2",
         "@clsh/web": "0.0.2"
       },
       "bin": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clsh/agent",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "clsh local agent — PTY manager, WebSocket server, auth, and ngrok tunnel",
   "license": "MIT",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clsh-dev",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Your Mac, in your pocket. Real terminal on your phone.",
   "license": "MIT",
   "repository": {
@@ -27,7 +27,7 @@
     "test": "echo \"No tests yet\""
   },
   "dependencies": {
-    "@clsh/agent": "0.0.1",
+    "@clsh/agent": "0.0.2",
     "@clsh/web": "0.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Bump `@clsh/agent` 0.0.1 → 0.0.2 (GitHub link in banner)
- Bump `clsh-dev` 0.1.2 → 0.1.3 (pulls updated agent)
- Already published to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)