### PR TITLE
fix: catch posix_spawnp crash during session reattach

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clsh/agent",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "clsh local agent — PTY manager, WebSocket server, auth, and ngrok tunnel",
   "license": "MIT",
   "repository": {

--- a/packages/agent/src/pty-manager.ts
+++ b/packages/agent/src/pty-manager.ts
@@ -1,5 +1,6 @@
 import { spawn, type IPty } from 'node-pty';
 import { randomUUID } from 'node:crypto';
+import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename } from 'node:path';
 import type { ShellType } from './types.js';
@@ -361,13 +362,26 @@ export class PTYManager {
       ? ['-CC', '-L', TMUX_SOCKET, '-f', this.tmuxConfPath, 'attach-session', '-t', tmuxName]
       : ['-CC', '-L', TMUX_SOCKET, 'attach-session', '-t', tmuxName];
 
-    const pty = spawn('tmux', args, {
-      name: 'xterm-256color',
-      cols,
-      rows,
-      cwd: savedCwd || homedir(),
-      env: buildSafeEnv(),
-    });
+    // Use homedir() as fallback if savedCwd doesn't exist
+    const cwd = savedCwd && existsSync(savedCwd) ? savedCwd : homedir();
+
+    let pty: ReturnType<typeof spawn>;
+    try {
+      pty = spawn('tmux', args, {
+        name: 'xterm-256color',
+        cols,
+        rows,
+        cwd,
+        env: buildSafeEnv(),
+      });
+    } catch {
+      // PTY spawn failed (e.g. posix_spawnp error) — clean up and skip
+      if (this.db) {
+        try { this.db.deletePtySession.run(sessionId); } catch { /* ignore */ }
+      }
+      killTmuxSession(tmuxName);
+      return null;
+    }
 
     const buffer: string[] = [];
     const dataListeners: Array<(data: string) => void> = [];

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clsh-dev",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Your Mac, in your pocket. Real terminal on your phone.",
   "license": "MIT",
   "repository": {
@@ -27,7 +27,7 @@
     "test": "echo \"No tests yet\""
   },
   "dependencies": {
-    "@clsh/agent": "0.0.2",
+    "@clsh/agent": "0.0.3",
     "@clsh/web": "0.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Wraps PTY `spawn()` in `reattach()` with try/catch so stale sessions don't crash the server on startup
- Validates `savedCwd` exists before using it (falls back to `homedir()`)
- On spawn failure: cleans up DB entry, kills orphaned tmux session, returns null

Fixes `posix_spawnp failed` crash when running `npx clsh-dev` with stale sessions in the database.

## Test plan
- [x] `npx turbo build` passes
- [ ] Run `npx clsh-dev` with stale sessions in `~/.clsh/clsh.db`
- [ ] Verify server starts without crashing