### PR TITLE
fix: chmod node-pty spawn-helper on startup

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clsh/agent",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "clsh local agent — PTY manager, WebSocket server, auth, and ngrok tunnel",
   "license": "MIT",
   "repository": {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3,6 +3,9 @@
 
 import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
+import { chmodSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { createRequire } from 'node:module';
 import { loadConfig } from './config.js';
 import { initDatabase } from './db.js';
 import { generateBootstrapToken, hashToken } from './auth.js';
@@ -34,7 +37,31 @@ function preventSleep(): (() => void) | null {
   }
 }
 
+/**
+ * npm may strip execute permission from node-pty's spawn-helper binary
+ * when installed via npx. This causes posix_spawnp to fail on all PTY
+ * spawns. Fix permissions at startup if needed.
+ */
+function fixNodePtyPermissions(): void {
+  try {
+    const require = createRequire(import.meta.url);
+    const ptyPkg = require.resolve('node-pty/package.json');
+    const ptyDir = dirname(ptyPkg);
+    const arch = process.arch === 'arm64' ? 'darwin-arm64' : 'darwin-x64';
+    const helper = join(ptyDir, 'prebuilds', arch, 'spawn-helper');
+    const st = statSync(helper);
+    if (!(st.mode & 0o111)) {
+      chmodSync(helper, st.mode | 0o755);
+    }
+  } catch {
+    // Not critical if we can't find/fix the helper (e.g. non-darwin, different node-pty version)
+  }
+}
+
 export async function main(): Promise<void> {
+  // 0. Fix node-pty spawn-helper permissions (npm/npx can strip +x)
+  fixNodePtyPermissions();
+
   // 0a. Check if macOS is configured for lid-close networking
   checkNetworkPersistence();
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clsh-dev",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Your Mac, in your pocket. Real terminal on your phone.",
   "license": "MIT",
   "repository": {
@@ -27,7 +27,7 @@
     "test": "echo \"No tests yet\""
   },
   "dependencies": {
-    "@clsh/agent": "0.0.3",
+    "@clsh/agent": "0.0.4",
     "@clsh/web": "0.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- npm/npx strips execute permissions from node-pty's prebuilt `spawn-helper` binary (`-rw-r--r--` instead of `-rwxr-xr-x`)
- This causes `posix_spawnp failed` on **every** PTY spawn when installed via `npx clsh-dev`
- Added `fixNodePtyPermissions()` at agent startup that detects and fixes the missing +x bit

Root cause: npm's tarball extraction doesn't preserve file permissions from the package.

## Test plan
- [x] Build passes
- [x] Reproduced: `spawn-helper` is `-rw-r--r--` after npx install
- [x] Verified: `chmod +x` fixes PTY spawn
- [ ] Run `npx clsh-dev@0.1.5` and create a session