### PR TITLE
fix: preserve tmux sessions across server restarts

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clsh/agent",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "clsh local agent — PTY manager, WebSocket server, auth, and ngrok tunnel",
   "license": "MIT",
   "repository": {

--- a/packages/agent/src/pty-manager.ts
+++ b/packages/agent/src/pty-manager.ts
@@ -104,6 +104,8 @@ export class PTYManager {
   private sessions = new Map<string, PTYSession>();
   private idleCheckInterval: ReturnType<typeof setInterval> | null = null;
   private updateListeners = new Map<string, Array<(meta: SessionMeta) => void>>();
+  /** When true, PTY exit handlers skip tmux/DB cleanup to preserve session persistence. */
+  private shuttingDown = false;
 
   private tmuxEnabled: boolean;
   private tmuxConfPath: string | null;
@@ -199,7 +201,7 @@ export class PTYManager {
       for (const listener of exitListeners) {
         listener(event);
       }
-      if (session.tmuxName) {
+      if (session.tmuxName && !this.shuttingDown) {
         killTmuxSession(session.tmuxName);
         if (this.db) {
           try { this.db.deletePtySession.run(session.id); } catch { /* ignore */ }
@@ -234,7 +236,7 @@ export class PTYManager {
       for (const listener of exitListeners) {
         listener(event);
       }
-      if (session.tmuxName) {
+      if (session.tmuxName && !this.shuttingDown) {
         killTmuxSession(session.tmuxName);
         if (this.db) {
           try { this.db.deletePtySession.run(session.id); } catch { /* ignore */ }
@@ -543,6 +545,7 @@ export class PTYManager {
    * tmux sessions and DB rows survive for rediscovery on next startup.
    */
   destroyAll(): void {
+    this.shuttingDown = true;
     for (const session of this.sessions.values()) {
       session.pty.kill();
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clsh-dev",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Your Mac, in your pocket. Real terminal on your phone.",
   "license": "MIT",
   "repository": {
@@ -27,7 +27,7 @@
     "test": "echo \"No tests yet\""
   },
   "dependencies": {
-    "@clsh/agent": "0.0.4",
+    "@clsh/agent": "0.0.5",
     "@clsh/web": "0.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- PTY `onExit` handler was killing tmux sessions and deleting DB entries on **every** exit, including graceful shutdown
- This meant sessions were destroyed when stopping `npx clsh-dev` (Ctrl+C), breaking persistence
- Added `shuttingDown` flag: `destroyAll()` sets it so exit handlers skip tmux/DB cleanup
- Sessions now survive server restarts and are recovered via `rediscoverAll()`

## Test plan
- [x] Build passes
- [x] E2E: create session, stop server (SIGINT), verify tmux session + DB survive
- [x] E2E: restart server, verify "Recovered 1 session(s)" message
- [x] Tested via actual npx binary path (not just local build)