### PR TITLE
fix: critical auth fixes (C2, C3, C4, H1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "test": "turbo run test",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "postinstall": "node scripts/fix-node-pty.js"
+    "postinstall": "node scripts/fix-node-pty.js",
+    "prepare": "cp scripts/pre-commit .git/hooks/pre-commit 2>/dev/null || true"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -9,10 +9,10 @@ import { createRequire } from 'node:module';
 import { loadConfig } from './config.js';
 import { initDatabase } from './db.js';
 import { generateBootstrapToken, hashToken } from './auth.js';
-import { createAppServer, startServer } from './server.js';
+import { createAppServer, startServer, updateAllowedOrigins } from './server.js';
 import { setupWebSocketHandler } from './ws-handler.js';
 import { PTYManager } from './pty-manager.js';
-import { createTunnel, printAccessInfo, startTunnelMonitor, registerShutdownHandlers } from './tunnel.js';
+import { createTunnel, printAccessInfo, startTunnelMonitor, registerShutdownHandlers, getTunnelUrl } from './tunnel.js';
 import { isTmuxAvailable, ensureTmuxConfig } from './tmux.js';
 import { checkNetworkPersistence } from './power.js';
 
@@ -75,9 +75,9 @@ export async function main(): Promise<void> {
   const { db, statements } = initDatabase(config.dbPath);
 
   // 3. Generate bootstrap token and store its hash
-  const bootstrapToken = generateBootstrapToken();
+  let currentBootstrapToken = generateBootstrapToken();
   const tokenId = randomUUID();
-  const tokenHash = hashToken(bootstrapToken);
+  const tokenHash = hashToken(currentBootstrapToken);
   statements.insertBootstrapToken.run(tokenId, tokenHash);
 
   // 4. tmux session persistence (control mode -CC for scrollback support)
@@ -126,17 +126,54 @@ export async function main(): Promise<void> {
   const tunnelPort = config.webPort !== config.port ? config.webPort : actualPort;
   const tunnel = await createTunnel(tunnelPort, config.ngrokAuthtoken, config.ngrokStaticDomain, config.tunnelMethod);
 
-  // 10. Print clean startup info
-  printAccessInfo(tunnel.url, bootstrapToken, tunnel.method);
+  // 10. Set allowed origins for CORS and WebSocket origin checks
+  updateAllowedOrigins(actualPort, tunnel.url);
 
-  // 11. Monitor tunnel health — auto-recovers after sleep/wake or SSH death
+  // 11. Print clean startup info
+  printAccessInfo(tunnel.url, currentBootstrapToken, tunnel.method);
+
+  // 12. Monitor tunnel health — auto-recovers after sleep/wake or SSH death
   const stopTunnelMonitor = startTunnelMonitor((newUrl, method) => {
-    // Tunnel was recreated with a (possibly new) URL — reprint access info
-    printAccessInfo(newUrl, bootstrapToken, method);
+    // Tunnel was recreated with a (possibly new) URL — reprint access info and update origins
+    updateAllowedOrigins(actualPort, newUrl);
+    printAccessInfo(newUrl, currentBootstrapToken, method);
   });
 
-  // 12. Register graceful shutdown handlers
+  // 13. Listen for Enter key to regenerate QR code with new one-time token
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.on('data', (key: Buffer) => {
+      const ch = key[0];
+      // Ctrl+C
+      if (ch === 3) {
+        process.kill(process.pid, 'SIGINT');
+        return;
+      }
+      // Enter key
+      if (ch === 13) {
+        currentBootstrapToken = generateBootstrapToken();
+        const newTokenId = randomUUID();
+        const newTokenHash = hashToken(currentBootstrapToken);
+        statements.insertBootstrapToken.run(newTokenId, newTokenHash);
+        const tunnelUrl = getTunnelUrl();
+        if (tunnelUrl) {
+          printAccessInfo(tunnelUrl, currentBootstrapToken, tunnel.method);
+        }
+      }
+    });
+    const dim = '\x1b[2m';
+    const r = '\x1b[0m';
+    console.log(`${dim}  Press Enter to generate a new QR code${r}`);
+    console.log('');
+  }
+
+  // 14. Register graceful shutdown handlers
   registerShutdownHandlers(() => {
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(false);
+      process.stdin.pause();
+    }
     stopCaffeinate?.();
     stopTunnelMonitor();
     ptyManager.destroyAll(); // Kills control clients but leaves tmux sessions alive

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -1,6 +1,6 @@
 import express, { type Express } from 'express';
 import { createServer as createNetServer } from 'node:net';
-import { createServer, type Server as HttpServer } from 'node:http';
+import { createServer, type Server as HttpServer, type IncomingMessage } from 'node:http';
 import { WebSocketServer } from 'ws';
 import { join, dirname } from 'node:path';
 import { existsSync } from 'node:fs';
@@ -9,6 +9,7 @@ import {
   generateBootstrapToken,
   verifyBootstrapToken,
   createSessionJWT,
+  hashToken,
 } from './auth.js';
 import { createSSERouter } from './sse-handler.js';
 import type { DbStatements } from './db.js';
@@ -18,6 +19,32 @@ export interface ServerContext {
   app: Express;
   httpServer: HttpServer;
   wss: WebSocketServer;
+}
+
+/**
+ * Set of allowed origins for CORS and WebSocket origin checks.
+ * Populated at startup and updated when tunnel URLs change.
+ */
+const allowedOrigins = new Set<string>();
+
+/**
+ * Updates the set of allowed origins based on the current server port and tunnel URL.
+ * Called at startup and whenever the tunnel is recreated.
+ */
+export function updateAllowedOrigins(port: number, tunnelUrl?: string): void {
+  allowedOrigins.clear();
+  // Local dev origins
+  allowedOrigins.add(`http://localhost:${port}`);
+  allowedOrigins.add(`http://127.0.0.1:${port}`);
+  // Vite dev server (default 4031)
+  allowedOrigins.add('http://localhost:4031');
+  allowedOrigins.add('http://127.0.0.1:4031');
+  if (tunnelUrl) {
+    try {
+      const url = new URL(tunnelUrl);
+      allowedOrigins.add(url.origin);
+    } catch { /* invalid URL — skip */ }
+  }
 }
 
 /**
@@ -57,12 +84,16 @@ export function createAppServer(
 ): ServerContext {
   const app = express();
 
-  // Middleware — CORS for development
-  app.use((_req, res, next) => {
-    res.header('Access-Control-Allow-Origin', '*');
+  // Middleware — dynamic CORS (restricted to allowed origins)
+  app.use((req, res, next) => {
+    const origin = req.headers.origin;
+    if (origin && allowedOrigins.has(origin)) {
+      res.header('Access-Control-Allow-Origin', origin);
+      res.header('Vary', 'Origin');
+    }
     res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
     res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-    if (_req.method === 'OPTIONS') {
+    if (req.method === 'OPTIONS') {
       res.sendStatus(204);
       return;
     }
@@ -106,7 +137,15 @@ export function createAppServer(
 
   // Create WebSocket server with native ping to detect dead connections.
   // Clients that don't respond to a ping within 30s are terminated.
-  const wss = new WebSocketServer({ server: httpServer });
+  const wss = new WebSocketServer({
+    server: httpServer,
+    verifyClient: (info: { origin: string; secure: boolean; req: IncomingMessage }) => {
+      const origin = info.origin;
+      // Allow connections with no origin header (non-browser clients, CLIs)
+      if (!origin) return true;
+      return allowedOrigins.has(origin);
+    },
+  });
 
   const WS_PING_INTERVAL = 30_000;
   const pingInterval = setInterval(() => {
@@ -145,6 +184,9 @@ function mountAuthRoutes(
         res.status(401).json({ error: 'Invalid or expired bootstrap token' });
         return;
       }
+
+      // Consume the token immediately — one-time use only
+      statements.deleteBootstrapToken.run(hashToken(token));
 
       const jwt = await createSessionJWT(
         { authMethod: 'bootstrap' },

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Pre-commit hook: reject staged .env files to prevent credential leaks
+
+STAGED_ENV=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^\.env|/\.env' || true)
+
+if [ -n "$STAGED_ENV" ]; then
+  echo ""
+  echo "ERROR: Attempting to commit .env file(s):"
+  echo "$STAGED_ENV"
+  echo ""
+  echo "These files may contain secrets (API keys, tokens)."
+  echo "If you really need to commit them, use: git commit --no-verify"
+  echo ""
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- **C2**: Bootstrap tokens are now one-time use (deleted from DB after JWT exchange). Press Enter in terminal to regenerate a new QR code with a fresh token.
- **C3**: Pre-commit hook rejects staged `.env` files to prevent credential leaks. Auto-installed via `prepare` script.
- **C4**: WebSocket connections verified against allowed origins (localhost, Vite dev, tunnel URL). Non-browser clients (no origin header) still allowed.
- **H1**: CORS `Access-Control-Allow-Origin` is now dynamic (checks against allowed origins set) instead of wildcard `*`. Includes `Vary: Origin` header.

## Test plan
- [ ] `npx turbo run typecheck lint build` passes
- [ ] Start agent, scan QR, authenticate successfully
- [ ] Press Enter in terminal, new QR appears with new token
- [ ] Old QR/token no longer works (returns 401)
- [ ] Check CORS headers are not wildcard
- [ ] Try WS connection from disallowed origin (should be rejected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)