### PR TITLE
feat: QR scanner for mobile auth + PWA install banner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4025,6 +4025,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "license": "Apache-2.0"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6363,7 +6369,7 @@
     },
     "packages/agent": {
       "name": "@clsh/agent",
-      "version": "0.0.2",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
         "@ngrok/ngrok": "^1.4.0",
@@ -6383,10 +6389,10 @@
     },
     "packages/cli": {
       "name": "clsh-dev",
-      "version": "0.1.3",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
-        "@clsh/agent": "0.0.2",
+        "@clsh/agent": "0.0.5",
         "@clsh/web": "0.0.2"
       },
       "bin": {
@@ -6405,6 +6411,7 @@
         "@xterm/addon-unicode11": "^0.8.0",
         "@xterm/addon-webgl": "^0.18.0",
         "@xterm/xterm": "^5.5.0",
+        "jsqr": "^1.4.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0"
       },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,7 +13,9 @@
     "url": "https://github.com/my-claude-utils/clsh/issues"
   },
   "type": "module",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "exports": {
     "./package.json": "./package.json",
     "./dist/*": "./dist/*"
@@ -26,19 +28,20 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "react": "^18.3.0",
-    "react-dom": "^18.3.0",
-    "@xterm/xterm": "^5.5.0",
-    "@xterm/addon-webgl": "^0.18.0",
     "@xterm/addon-fit": "^0.10.0",
-    "@xterm/addon-unicode11": "^0.8.0"
+    "@xterm/addon-unicode11": "^0.8.0",
+    "@xterm/addon-webgl": "^0.18.0",
+    "@xterm/xterm": "^5.5.0",
+    "jsqr": "^1.4.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.0.0",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.0",
     "tailwindcss": "^4.0.0",
-    "@tailwindcss/vite": "^4.0.0",
     "vite": "^6.0.0"
   }
 }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -4,6 +4,7 @@ import { TerminalView } from './components/TerminalView';
 import SkinStudio from './components/SkinStudio';
 import { SettingsPanel } from './components/SettingsPanel';
 import { AuthScreen } from './components/AuthScreen';
+import { PWAInstallBanner } from './components/PWAInstallBanner';
 import { useAuth } from './hooks/useAuth';
 import { useSessionManager } from './hooks/useSessionManager';
 import { useSkin } from './hooks/useSkin';
@@ -134,6 +135,7 @@ export function App() {
           sessionCount={sessions.length}
         />
       )}
+      <PWAInstallBanner />
     </>
   );
 }

--- a/packages/web/src/components/AuthScreen.tsx
+++ b/packages/web/src/components/AuthScreen.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, type FormEvent, type ClipboardEvent } from 'react';
 import type { AuthState } from '../hooks/useAuth';
 import { IOSKeyboard } from './IOSKeyboard';
+import { QRScanner } from './QRScanner';
 import { useIsMobile } from '../hooks/useMediaQuery';
 
 interface AuthScreenProps {
@@ -11,6 +12,7 @@ interface AuthScreenProps {
 export function AuthScreen({ auth, onBootstrapSubmit }: AuthScreenProps) {
   const [bootstrapToken, setBootstrapToken] = useState('');
   const [showKeyboard, setShowKeyboard] = useState(false);
+  const [showScanner, setShowScanner] = useState(false);
   const isMobile = useIsMobile();
   const mobileInputRef = useRef<HTMLInputElement>(null);
 
@@ -58,8 +60,25 @@ export function AuthScreen({ auth, onBootstrapSubmit }: AuthScreenProps) {
     }
   };
 
+  const handleQRScan = async (token: string) => {
+    setShowScanner(false);
+    const success = await onBootstrapSubmit(token);
+    if (!success) {
+      // Token was invalid or expired
+      setBootstrapToken('');
+    }
+  };
+
   return (
     <div className="relative h-full bg-clsh-bg overflow-hidden">
+      {/* QR Scanner fullscreen overlay */}
+      {showScanner && (
+        <QRScanner
+          onScan={(token) => void handleQRScan(token)}
+          onClose={() => setShowScanner(false)}
+        />
+      )}
+
       {/* Centered form area — stays in place when keyboard opens */}
       <div className="flex h-full items-center justify-center px-4">
         <div className="w-full max-w-sm">
@@ -69,9 +88,24 @@ export function AuthScreen({ auth, onBootstrapSubmit }: AuthScreenProps) {
               clsh
             </h1>
             <p className="mt-2 text-sm text-neutral-500">
-              Paste the token shown in your terminal
+              {isMobile ? 'Scan the QR code from your terminal' : 'Paste the token shown in your terminal'}
             </p>
           </div>
+
+          {/* QR Scan button (mobile primary action) */}
+          {isMobile && (
+            <button
+              type="button"
+              onClick={() => setShowScanner(true)}
+              disabled={auth.loading}
+              className="mb-4 flex w-full items-center justify-center gap-2 rounded-md bg-clsh-orange px-4 py-3 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <rect x="3" y="3" width="7" height="7" /><rect x="14" y="3" width="7" height="7" /><rect x="3" y="14" width="7" height="7" /><rect x="14" y="14" width="7" height="7" />
+              </svg>
+              Scan QR Code
+            </button>
+          )}
 
           {/* Bootstrap token form */}
           <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
@@ -157,8 +191,14 @@ export function AuthScreen({ auth, onBootstrapSubmit }: AuthScreenProps) {
           )}
 
           <p className="mt-6 text-center text-xs text-neutral-600">
-            Run <code className="text-neutral-400">npx clsh-dev</code> on your Mac and scan the QR code, or copy the token from the terminal output.
+            Run <code className="text-neutral-400">npx clsh-dev</code> on your Mac{isMobile ? ' and scan the QR code' : ', then copy the token from the terminal output'}.
           </p>
+
+          {auth.error && isMobile && (
+            <p className="mt-2 text-center text-xs text-neutral-500">
+              Press Enter in your terminal to generate a new QR code.
+            </p>
+          )}
         </div>
       </div>
 

--- a/packages/web/src/components/PWAInstallBanner.tsx
+++ b/packages/web/src/components/PWAInstallBanner.tsx
@@ -1,0 +1,108 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+const DISMISS_KEY = 'clsh_pwa_banner_dismissed';
+const SHOW_DELAY_MS = 30_000;
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+/**
+ * PWA install banner. Shows after 30 seconds on mobile browsers
+ * that are NOT already running as a standalone PWA.
+ *
+ * - Android: intercepts `beforeinstallprompt` event for native install flow
+ * - iOS: shows manual instructions (Share > Add to Home Screen)
+ * - Dismissible, remembers dismissal in localStorage
+ */
+export function PWAInstallBanner() {
+  const [visible, setVisible] = useState(false);
+  const deferredPrompt = useRef<BeforeInstallPromptEvent | null>(null);
+  const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+
+  useEffect(() => {
+    // Skip if already running as PWA
+    if (window.matchMedia('(display-mode: standalone)').matches) return;
+
+    // Skip if previously dismissed
+    try {
+      if (localStorage.getItem(DISMISS_KEY)) return;
+    } catch { /* storage unavailable */ }
+
+    // Capture Android install prompt
+    const handlePrompt = (e: Event) => {
+      e.preventDefault();
+      deferredPrompt.current = e as BeforeInstallPromptEvent;
+    };
+    window.addEventListener('beforeinstallprompt', handlePrompt);
+
+    // Show banner after delay
+    const timer = setTimeout(() => setVisible(true), SHOW_DELAY_MS);
+
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener('beforeinstallprompt', handlePrompt);
+    };
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setVisible(false);
+    try {
+      localStorage.setItem(DISMISS_KEY, '1');
+    } catch { /* ignore */ }
+  }, []);
+
+  const handleInstall = useCallback(async () => {
+    if (deferredPrompt.current) {
+      await deferredPrompt.current.prompt();
+      deferredPrompt.current = null;
+    }
+    dismiss();
+  }, [dismiss]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-4 left-4 right-4 z-40 rounded-lg border border-clsh-border bg-clsh-surface p-4 shadow-lg">
+      <div className="flex items-start gap-3">
+        <div className="flex-1">
+          <p className="text-sm font-medium text-white">Install clsh</p>
+          {isIOS ? (
+            <p className="mt-1 text-xs text-neutral-400">
+              Tap <span className="inline-block align-text-bottom">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="inline">
+                  <path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8M16 6l-4-4-4 4M12 2v13" />
+                </svg>
+              </span> Share, then <strong>Add to Home Screen</strong>.
+            </p>
+          ) : (
+            <p className="mt-1 text-xs text-neutral-400">
+              Add clsh to your home screen for a fullscreen terminal experience.
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          {!isIOS && deferredPrompt.current && (
+            <button
+              onClick={() => void handleInstall()}
+              className="rounded-md bg-clsh-orange px-3 py-1.5 text-xs font-medium text-white transition-opacity hover:opacity-90"
+            >
+              Install
+            </button>
+          )}
+          <button
+            onClick={dismiss}
+            className="rounded p-1 text-neutral-500 transition-colors hover:text-white"
+            aria-label="Dismiss"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/QRScanner.tsx
+++ b/packages/web/src/components/QRScanner.tsx
@@ -1,0 +1,154 @@
+import { useRef, useEffect, useState, useCallback } from 'react';
+import jsQR from 'jsqr';
+
+interface QRScannerProps {
+  onScan: (token: string) => void;
+  onClose: () => void;
+}
+
+/**
+ * Fullscreen camera overlay that scans QR codes for bootstrap tokens.
+ * Uses the rear camera and runs jsQR on each video frame.
+ */
+export function QRScanner({ onScan, onClose }: QRScannerProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const rafRef = useRef<number>(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const cleanup = useCallback(() => {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    if (streamRef.current) {
+      for (const track of streamRef.current.getTracks()) track.stop();
+      streamRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const start = async () => {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: 'environment' },
+        });
+        if (cancelled) {
+          for (const track of stream.getTracks()) track.stop();
+          return;
+        }
+        streamRef.current = stream;
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          await videoRef.current.play();
+          scan();
+        }
+      } catch {
+        if (!cancelled) setError('Camera access denied. Check your browser permissions.');
+      }
+    };
+
+    const scan = () => {
+      const video = videoRef.current;
+      const canvas = canvasRef.current;
+      if (!video || !canvas || cancelled) return;
+
+      const ctx = canvas.getContext('2d', { willReadFrequently: true });
+      if (!ctx) return;
+
+      const tick = () => {
+        if (cancelled || !video.videoWidth) {
+          rafRef.current = requestAnimationFrame(tick);
+          return;
+        }
+
+        canvas.width = video.videoWidth;
+        canvas.height = video.videoHeight;
+        ctx.drawImage(video, 0, 0);
+
+        const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+        const code = jsQR(imageData.data, imageData.width, imageData.height);
+
+        if (code?.data) {
+          const token = extractToken(code.data);
+          if (token) {
+            cleanup();
+            onScan(token);
+            return;
+          }
+        }
+
+        rafRef.current = requestAnimationFrame(tick);
+      };
+
+      rafRef.current = requestAnimationFrame(tick);
+    };
+
+    void start();
+
+    return () => {
+      cancelled = true;
+      cleanup();
+    };
+  }, [onScan, cleanup]);
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black flex flex-col">
+      {/* Close button */}
+      <button
+        onClick={() => { cleanup(); onClose(); }}
+        className="absolute top-4 right-4 z-10 rounded-full bg-black/60 p-2 text-white"
+        aria-label="Close scanner"
+      >
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M18 6L6 18M6 6l12 12" />
+        </svg>
+      </button>
+
+      {error ? (
+        <div className="flex flex-1 items-center justify-center px-6 text-center">
+          <div>
+            <p className="text-white text-sm mb-4">{error}</p>
+            <p className="text-neutral-400 text-xs">
+              Generate a new QR code by pressing Enter in your terminal,
+              then try again or paste the token manually.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <>
+          <video ref={videoRef} className="flex-1 object-cover" playsInline muted />
+          <canvas ref={canvasRef} className="hidden" />
+
+          {/* Viewfinder overlay */}
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+            <div className="w-64 h-64 border-2 border-[#F97316] rounded-lg" />
+          </div>
+
+          <div className="absolute bottom-8 left-0 right-0 text-center">
+            <p className="text-white text-sm">Point your camera at the QR code</p>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+/** Extracts the bootstrap token from a scanned URL. Supports ?token= and #token= formats. */
+function extractToken(data: string): string | null {
+  try {
+    const url = new URL(data);
+    // Hash fragment format: #token=xxx
+    if (url.hash) {
+      const hashParams = new URLSearchParams(url.hash.slice(1));
+      const token = hashParams.get('token');
+      if (token) return token;
+    }
+    // Query param format: ?token=xxx
+    const token = url.searchParams.get('token');
+    if (token) return token;
+  } catch {
+    // Not a URL, ignore
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- **QR Scanner**: Opens rear camera on mobile to scan bootstrap token QR codes. Uses jsQR (~45KB). Supports both `?token=` and `#token=` URL formats.
- **AuthScreen**: Mobile shows "Scan QR Code" as primary action above paste input. Desktop paste-only flow unchanged.
- **PWA Install Banner**: Shows after 30s in mobile browsers (not standalone PWA). Android native install prompt, iOS manual instructions. Dismissible with localStorage persistence.

## Test plan
- [ ] `npx turbo run typecheck lint build` passes
- [ ] On mobile: "Scan QR Code" button appears above paste input
- [ ] Camera opens, scans QR from terminal, authenticates
- [ ] On desktop: no QR scan button, paste-only flow
- [ ] PWA banner appears after 30s in mobile browser
- [ ] Dismissing banner persists (doesn't reappear)
- [ ] Banner does not appear if already running as PWA

🤖 Generated with [Claude Code](https://claude.com/claude-code)