### PR TITLE
chore: bump versions for npm publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6396,7 +6396,7 @@
     },
     "packages/agent": {
       "name": "@clsh/agent",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "@ngrok/ngrok": "^1.4.0",
@@ -6417,7 +6417,7 @@
     },
     "packages/cli": {
       "name": "clsh-dev",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@clsh/agent": "0.0.5",
@@ -6430,9 +6430,38 @@
         "tsx": "^4.19.0"
       }
     },
+    "packages/cli/node_modules/@clsh/agent": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@clsh/agent/-/agent-0.0.5.tgz",
+      "integrity": "sha512-FcFE7m//7xd0oVPWnRQvFJ2vqIVjs+OjQPF13D+mF1lJuT70wZTE36bcAbQsGkczrATDbPkNpgru72wZQJUp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@ngrok/ngrok": "^1.4.0",
+        "better-sqlite3": "^11.0.0",
+        "express": "^4.21.0",
+        "jose": "^5.9.0",
+        "node-pty": "^1.0.0",
+        "qrcode-terminal": "^0.12.0",
+        "ws": "^8.18.0"
+      }
+    },
+    "packages/cli/node_modules/@clsh/web": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@clsh/web/-/web-0.0.2.tgz",
+      "integrity": "sha512-BOG0PT+WRKHl3rKODOZG+wcKFAwmB25k3rv4n8OCk1i603szaC6r5VFSDP3ZrDRFPMl7m5yzPL5F/NW3bKoLRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-unicode11": "^0.8.0",
+        "@xterm/addon-webgl": "^0.18.0",
+        "@xterm/xterm": "^5.5.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
+      }
+    },
     "packages/web": {
       "name": "@clsh/web",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clsh/agent",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "clsh local agent — PTY manager, WebSocket server, auth, and ngrok tunnel",
   "license": "MIT",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clsh-dev",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Your Mac, in your pocket. Real terminal on your phone.",
   "license": "MIT",
   "repository": {
@@ -13,7 +13,9 @@
     "url": "https://github.com/my-claude-utils/clsh/issues"
   },
   "type": "module",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "bin": {
     "clsh-dev": "dist/index.js"
   },
@@ -27,8 +29,8 @@
     "test": "echo \"No tests yet\""
   },
   "dependencies": {
-    "@clsh/agent": "0.0.5",
-    "@clsh/web": "0.0.2"
+    "@clsh/agent": "0.0.6",
+    "@clsh/web": "0.0.3"
   },
   "devDependencies": {
     "tsx": "^4.19.0"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clsh/web",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "clsh web frontend — terminal UI with MacBook Pro frame",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- @clsh/web 0.0.2 → 0.0.3
- @clsh/agent 0.0.5 → 0.0.6
- clsh-dev 0.1.6 → 0.1.7

Already published to npm. This syncs the repo.