### PR TITLE
feat: allow native keyboard on iPad and desktop

### DIFF
--- a/packages/agent/src/tunnel.ts
+++ b/packages/agent/src/tunnel.ts
@@ -196,6 +196,7 @@ export function printAccessInfo(
     console.log(`${o}  Scan to connect ${dim}(token embedded in QR)${r}`);
     console.log('');
     console.log(`${o}  URL:   ${r}${publicUrl}`);
+    console.log(`${o}  Token: ${r}${bootstrapToken}  ${dim}(one-time, expires in 5 min)${r}`);
     console.log(`${o}  Mode:  ${r}${method === 'ngrok' ? 'remote (ngrok)' : method === 'ssh' ? 'remote (ssh)' : 'local Wi-Fi only'}`);
     if (method === 'local') {
       console.log('');

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -11,6 +11,7 @@ import { LockScreen } from './components/LockScreen';
 import { useAuth } from './hooks/useAuth';
 import { useSessionManager } from './hooks/useSessionManager';
 import { useSkin } from './hooks/useSkin';
+import { useNativeKeyboard } from './hooks/useNativeKeyboard';
 import { useLockScreen } from './hooks/useLockScreen';
 import { getBiometricIds, getClientPwdHash } from './lib/lock-screen';
 import type { View } from './lib/types';
@@ -19,6 +20,7 @@ export function App() {
   const { auth, authenticateWithBootstrap, authenticateWithPassword, authenticateWithBiometric, handleUnauthorized } = useAuth();
   const { sessions, wsClient, messageBus, createSession, closeSession, getSessionOutput, setSessionSnapshot, renameSession, status: wsStatus } = useSessionManager(auth, handleUnauthorized);
   const { skin, setSkin, perKeyColors, setPerKeyColors } = useSkin();
+  const { nativeKeyboard, setNativeKeyboard } = useNativeKeyboard();
   const { isLocked, needsSetup, biometricAvailable, hasBiometric, unlock, completeLockSetup } = useLockScreen(auth.isAuthenticated);
 
   const [view, setView] = useState<View>('grid');
@@ -150,6 +152,7 @@ export function App() {
           onRenameSession={renameSession}
           skin={skin}
           perKeyColors={perKeyColors}
+          nativeKeyboard={nativeKeyboard}
         />
         {settingsOpen && (
           <SettingsPanel
@@ -168,6 +171,8 @@ export function App() {
         perKeyColors={perKeyColors}
         onPerKeyColorChange={setPerKeyColors}
         onClose={handleCloseSkinStudio}
+        nativeKeyboard={nativeKeyboard}
+        onNativeKeyboardChange={setNativeKeyboard}
       />
     );
   } else {

--- a/packages/web/src/components/AuthScreen.tsx
+++ b/packages/web/src/components/AuthScreen.tsx
@@ -339,7 +339,7 @@ export function AuthScreen({ auth, onBootstrapSubmit, onPasswordSubmit, onBiomet
               <form onSubmit={(e) => void handleBootstrapSubmit(e)} className="space-y-4">
                 <div>
                   <label htmlFor="bootstrap-token" className="mb-1.5 block text-xs font-medium text-neutral-400">
-                    Bootstrap Token
+                    One-Time Token
                   </label>
                   <div className="relative flex items-center">
                     <input
@@ -386,7 +386,7 @@ export function AuthScreen({ auth, onBootstrapSubmit, onPasswordSubmit, onBiomet
               )}
 
               <p className="mt-6 text-center text-xs text-neutral-600">
-                Run <code className="text-neutral-400">npx clsh-dev</code> on your Mac, then copy the token from the terminal output.
+                Run <code className="text-neutral-400">npx clsh-dev</code> on your Mac, then copy the one-time token from the terminal output.
               </p>
             </>
           )}

--- a/packages/web/src/components/SkinStudio.tsx
+++ b/packages/web/src/components/SkinStudio.tsx
@@ -46,7 +46,10 @@ export default function SkinStudio({
   onSkinChange,
   perKeyColors,
   onClose,
+  nativeKeyboard,
+  onNativeKeyboardChange,
 }: SkinStudioProps) {
+  const showNativeToggle = typeof window !== 'undefined' && window.innerWidth >= 768;
 
   return (
     <div
@@ -97,6 +100,83 @@ export default function SkinStudio({
           {SKIN_ORDER.length} themes
         </span>
       </div>
+
+      {/* ── Native Keyboard Toggle (tablet/desktop only) ─────── */}
+      {showNativeToggle && (
+        <div
+          style={{
+            padding: '12px 16px',
+            borderBottom: '1px solid #1a1a1a',
+            background: '#0a0a0a',
+            flexShrink: 0,
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => onNativeKeyboardChange(!nativeKeyboard)}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              width: '100%',
+              background: '#111',
+              border: '1px solid #222',
+              borderRadius: 10,
+              padding: '12px 14px',
+              cursor: 'pointer',
+            }}
+          >
+            <div style={{ textAlign: 'left' }}>
+              <div
+                style={{
+                  fontSize: 13,
+                  fontWeight: 600,
+                  color: '#ccc',
+                  fontFamily: "'Space Grotesk', -apple-system, sans-serif",
+                }}
+              >
+                Native Keyboard
+              </div>
+              <div
+                style={{
+                  fontSize: 10,
+                  color: '#555',
+                  marginTop: 2,
+                  fontFamily: "'JetBrains Mono', monospace",
+                }}
+              >
+                Use your device's physical keyboard
+              </div>
+            </div>
+            {/* Toggle switch */}
+            <div
+              style={{
+                width: 44,
+                height: 24,
+                borderRadius: 12,
+                background: nativeKeyboard ? '#f97316' : '#333',
+                position: 'relative',
+                transition: 'background 0.2s',
+                flexShrink: 0,
+                marginLeft: 12,
+              }}
+            >
+              <div
+                style={{
+                  width: 20,
+                  height: 20,
+                  borderRadius: '50%',
+                  background: '#fff',
+                  position: 'absolute',
+                  top: 2,
+                  left: nativeKeyboard ? 22 : 2,
+                  transition: 'left 0.2s',
+                }}
+              />
+            </div>
+          </button>
+        </div>
+      )}
 
       {/* ── Live Preview ────────────────────────────────────────── */}
       <div style={{ background: '#111111', padding: 16, flexShrink: 0 }}>

--- a/packages/web/src/components/TerminalView.tsx
+++ b/packages/web/src/components/TerminalView.tsx
@@ -22,9 +22,10 @@ export function TerminalView({
   onOpenSettings,
   skin,
   perKeyColors,
+  nativeKeyboard,
 }: TerminalViewProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const { terminal, write, getDimensions, captureScreen, scrollToBottom } = useTerminal(containerRef);
+  const { terminal, write, getDimensions, captureScreen, scrollToBottom } = useTerminal(containerRef, { nativeKeyboard });
 
   // Rename editing state — lifted here so we can intercept keyboard input
   const [renaming, setRenaming] = useState(false);
@@ -51,7 +52,7 @@ export function TerminalView({
     return unsubscribe;
   }, [terminal, messageBus, session.id, write, getSessionOutput]);
 
-  // Wire terminal input and resize to WebSocket
+  // Wire terminal resize to WebSocket
   useEffect(() => {
     if (!terminal || !wsClient) return;
 
@@ -123,6 +124,15 @@ export function TerminalView({
     [renaming, commitRename, cancelRename, wsClient, session.id, scrollToBottom],
   );
 
+  // When native keyboard is enabled, wire xterm's onData to send keystrokes
+  useEffect(() => {
+    if (!terminal || !nativeKeyboard) return;
+    const disposable = terminal.onData((data: string) => {
+      handleKey(data);
+    });
+    return () => disposable.dispose();
+  }, [terminal, nativeKeyboard, handleKey]);
+
   const handleBack = useCallback(() => {
     onBack(captureScreen());
   }, [onBack, captureScreen]);
@@ -159,11 +169,15 @@ export function TerminalView({
         }}
       />
 
-      <ContextStrip onKey={handleKey} />
-      {skin === 'ios-terminal' ? (
-        <IOSKeyboard onKey={handleKey} skin={skin} perKeyColors={perKeyColors} />
-      ) : (
-        <MacBookKeyboard onKey={handleKey} skin={skin} perKeyColors={perKeyColors} />
+      {!nativeKeyboard && (
+        <>
+          <ContextStrip onKey={handleKey} />
+          {skin === 'ios-terminal' ? (
+            <IOSKeyboard onKey={handleKey} skin={skin} perKeyColors={perKeyColors} />
+          ) : (
+            <MacBookKeyboard onKey={handleKey} skin={skin} perKeyColors={perKeyColors} />
+          )}
+        </>
       )}
     </div>
   );

--- a/packages/web/src/hooks/useNativeKeyboard.ts
+++ b/packages/web/src/hooks/useNativeKeyboard.ts
@@ -1,0 +1,26 @@
+import { useState, useCallback } from 'react';
+
+const STORAGE_KEY = 'clsh_native_keyboard';
+
+function load(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function useNativeKeyboard() {
+  const [nativeKeyboard, setNativeKeyboardState] = useState(load);
+
+  const setNativeKeyboard = useCallback((enabled: boolean) => {
+    setNativeKeyboardState(enabled);
+    try {
+      localStorage.setItem(STORAGE_KEY, String(enabled));
+    } catch {
+      // localStorage unavailable
+    }
+  }, []);
+
+  return { nativeKeyboard, setNativeKeyboard } as const;
+}

--- a/packages/web/src/hooks/useTerminal.ts
+++ b/packages/web/src/hooks/useTerminal.ts
@@ -30,6 +30,7 @@ interface UseTerminalReturn {
  */
 export function useTerminal(
   containerRef: RefObject<HTMLDivElement | null>,
+  options?: { nativeKeyboard?: boolean },
 ): UseTerminalReturn {
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
@@ -81,28 +82,8 @@ export function useTerminal(
 
       try { fitAddon.fit(); } catch { /* ignore */ }
 
-      // Suppress iOS keyboard on xterm's helper textarea completely:
-      // move it off-screen and remove pointer events so tapping the
-      // terminal area never triggers the iOS system keyboard.
-      const suppressTextarea = () => {
-        container.querySelectorAll<HTMLTextAreaElement>('.xterm-helper-textarea').forEach((t) => {
-          t.setAttribute('inputmode', 'none');
-          t.setAttribute('readonly', 'readonly');
-          t.style.position = 'fixed';
-          t.style.top = '-9999px';
-          t.style.left = '-9999px';
-          t.style.pointerEvents = 'none';
-          t.style.opacity = '0';
-          // Blur in case it already has focus
-          t.blur();
-        });
-      };
-      suppressTextarea();
-      // xterm may recreate the textarea on first input event — rerun
-      setTimeout(suppressTextarea, 150);
-
-      // Prevent iOS keyboard on any tap inside the terminal area
-      container.addEventListener('touchstart', suppressTextarea, { passive: true });
+      // Textarea suppression is handled by a separate effect that reacts
+      // to the nativeKeyboard option (see below).
 
       // Add momentum scrolling to the xterm viewport
       addMomentumScroll(terminal, container);
@@ -140,6 +121,54 @@ export function useTerminal(
       // will unmount anyway, and calling setState on unmount causes warnings.
     };
   }, [containerRef]);
+
+  // Reactive textarea suppression: suppress iOS keyboard unless native keyboard is enabled.
+  const nativeKeyboard = options?.nativeKeyboard ?? false;
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !terminalReady) return;
+
+    const textareas = () =>
+      container.querySelectorAll<HTMLTextAreaElement>('.xterm-helper-textarea');
+
+    if (nativeKeyboard) {
+      // Restore xterm's textarea so physical keyboard input works
+      textareas().forEach((t) => {
+        t.removeAttribute('inputmode');
+        t.removeAttribute('readonly');
+        t.style.position = '';
+        t.style.top = '';
+        t.style.left = '';
+        t.style.pointerEvents = '';
+        t.style.opacity = '';
+        t.focus();
+      });
+      return; // no suppression, no touchstart listener
+    }
+
+    // Suppress: move off-screen, prevent iOS keyboard
+    const suppress = () => {
+      textareas().forEach((t) => {
+        t.setAttribute('inputmode', 'none');
+        t.setAttribute('readonly', 'readonly');
+        t.style.position = 'fixed';
+        t.style.top = '-9999px';
+        t.style.left = '-9999px';
+        t.style.pointerEvents = 'none';
+        t.style.opacity = '0';
+        t.blur();
+      });
+    };
+    suppress();
+    // xterm may recreate the textarea on first input event
+    const timer = setTimeout(suppress, 150);
+    container.addEventListener('touchstart', suppress, { passive: true });
+
+    return () => {
+      clearTimeout(timer);
+      container.removeEventListener('touchstart', suppress);
+    };
+  }, [containerRef, terminalReady, nativeKeyboard]);
 
   const write = useCallback((data: string) => {
     terminalRef.current?.write(data);

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -81,6 +81,7 @@ export interface TerminalViewProps {
   onRenameSession: (sessionId: string, name: string) => void;
   skin: SkinId;
   perKeyColors: PerKeyColors;
+  nativeKeyboard: boolean;
 }
 
 export interface MacBookKeyboardProps {
@@ -100,4 +101,6 @@ export interface SkinStudioProps {
   perKeyColors: PerKeyColors;
   onPerKeyColorChange: (colors: PerKeyColors) => void;
   onClose: () => void;
+  nativeKeyboard: boolean;
+  onNativeKeyboardChange: (enabled: boolean) => void;
 }


### PR DESCRIPTION
## Summary

Resolves #24 — our first community issue! 🎉

- **Native keyboard toggle** in Skin Studio, visible only on iPad/desktop (screen width >= 768px)
- When enabled: xterm.js textarea is restored, `terminal.onData` wires physical keystrokes to the PTY, on-screen keyboard and context strip are hidden
- When disabled (default): existing behavior unchanged, on-screen keyboard works as before
- **CLI token display**: one-time bootstrap token now shown in plain text in `npx clsh-dev` output for easy copy-paste on desktop
- **Auth screen**: label updated from "Bootstrap Token" to "One-Time Token" for clarity

## Files changed

| File | Change |
|------|--------|
| `packages/web/src/hooks/useNativeKeyboard.ts` | New hook — localStorage-backed toggle |
| `packages/web/src/hooks/useTerminal.ts` | Textarea suppression now reactive to `nativeKeyboard` |
| `packages/web/src/components/TerminalView.tsx` | Conditional `onData` handler + keyboard visibility |
| `packages/web/src/components/SkinStudio.tsx` | Toggle UI with iOS-style switch |
| `packages/web/src/App.tsx` | Wire hook through to components |
| `packages/web/src/lib/types.ts` | Props updated |
| `packages/agent/src/tunnel.ts` | Print token in CLI output |
| `packages/web/src/components/AuthScreen.tsx` | "One-Time Token" label |

## Test plan

- [ ] Desktop (>= 768px): Toggle visible in Skin Studio, enables physical keyboard input
- [ ] Phone (< 768px): Toggle NOT visible, on-screen keyboard works as before
- [ ] iPad: Toggle visible, physical keyboard works when external keyboard connected
- [ ] `npx clsh-dev` terminal output shows token in plain text
- [ ] Token is single-use and expires after 5 minutes (no security regression)
- [ ] Settings persist across page reloads (localStorage)