### PR TITLE
chore: bump versions for npm publish

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clsh/agent",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "clsh local agent — PTY manager, WebSocket server, auth, and ngrok tunnel",
   "license": "MIT",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clsh-dev",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Your Mac, in your pocket. Real terminal on your phone.",
   "license": "MIT",
   "repository": {
@@ -29,8 +29,8 @@
     "test": "echo \"No tests yet\""
   },
   "dependencies": {
-    "@clsh/agent": "0.0.7",
-    "@clsh/web": "0.0.4"
+    "@clsh/agent": "0.0.8",
+    "@clsh/web": "0.0.5"
   },
   "devDependencies": {
     "tsx": "^4.19.0"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clsh/web",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "clsh web frontend — terminal UI with MacBook Pro frame",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Version bumps for the native keyboard feature release.

- `@clsh/web` 0.0.4 → 0.0.5
- `@clsh/agent` 0.0.7 → 0.0.8
- `clsh-dev` 0.1.8 → 0.1.9