### PR TITLE
chore: bump versions for npm publish (v0.1.10)

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clsh/agent",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "clsh local agent — PTY manager, WebSocket server, auth, and ngrok tunnel",
   "license": "MIT",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clsh-dev",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Your Mac, in your pocket. Real terminal on your phone.",
   "license": "MIT",
   "repository": {
@@ -29,7 +29,7 @@
     "test": "echo \"No tests yet\""
   },
   "dependencies": {
-    "@clsh/agent": "0.0.8",
+    "@clsh/agent": "0.0.9",
     "@clsh/web": "0.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- @clsh/agent 0.0.8 → 0.0.9 (libsql migration from PR #41)
- clsh-dev 0.1.9 → 0.1.10

Already published to npm.